### PR TITLE
adding binary object download support

### DIFF
--- a/plugins/modules/gcp_storage_object.py
+++ b/plugins/modules/gcp_storage_object.py
@@ -231,8 +231,8 @@ def main():
 def download_file(module):
     auth = GcpSession(module, 'storage')
     data = auth.get(media_link(module))
-    with open(module.params['dest'], 'w') as f:
-        f.write(data.text.encode('utf8'))
+    with open(module.params['dest'], 'wb') as f:
+        f.write(data.content)
     return fetch_resource(module, self_link(module))
 
 


### PR DESCRIPTION
See issues https://github.com/ansible/ansible_collections_google/issues/26 and https://github.com/ansible/ansible_collections_google/issues/26 .

This fixes an issue with downloading non textual files from GCS.  It opens the file in binary mode and then writes the content to the file.

It uses the requests binary response content: https://requests.kennethreitz.org/en/master/user/quickstart/#binary-response-content