### PR TITLE
fixing pep8 sanity test doc fragments file

### DIFF
--- a/plugins/doc_fragment/gcp.py
+++ b/plugins/doc_fragment/gcp.py
@@ -5,6 +5,9 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+__metaclass__ = type
+
+
 class ModuleDocFragment(object):
     # GCP doc fragment.
     DOCUMENTATION = r'''


### PR DESCRIPTION
fix for sanity test 
```ERROR: Found 1 pep8 issue(s) which need to be resolved:
ERROR: plugins/doc_fragment/gcp.py:10:1: E302: expected 2 blank lines, found 1
```

tested and passed with this fix