### PR TITLE
fixing for sanity test metaclass

### DIFF
--- a/plugins/module_utils/gcp_utils.py
+++ b/plugins/module_utils/gcp_utils.py
@@ -3,6 +3,8 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+__metaclass__ = type
+
 try:
     import requests
     HAS_REQUESTS = True


### PR DESCRIPTION
fix addressing 
```
ERROR: plugins/module_utils/gcp_utils.py:0:0: missing: __metaclass__ = type
```
tested locally and passes